### PR TITLE
fix: remove the sleep parameter

### DIFF
--- a/cicd/water-notations/templates/dataloadjob.yaml
+++ b/cicd/water-notations/templates/dataloadjob.yaml
@@ -40,8 +40,7 @@ spec:
                   set -eux pipefail &&
                   export DATABASE_URL=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@{{ .Values.app_name }}-postgres-svc:5432/$POSTGRES_DB &&
                   make clean_targets &&
-                  make all &&
-                  sleep 30000
+                  make all
             env:
             - name: POSTGRES_USER
               valueFrom:


### PR DESCRIPTION
Getting notifications about the duration that this job is taking, so removing the sleep parameter from it.

The sleep parameter was originally injected into the job to allow post run analysis to verify that the job had completed what it was suppose to do.   This should no longer be required as it is running in a prod namespace